### PR TITLE
Update brant.R

### DIFF
--- a/R/brant.R
+++ b/R/brant.R
@@ -1,6 +1,7 @@
 brant <- function(model,by.var=F){
   y_name = as.character(formula(model))[2]
   x_names = as.character(formula(model))[3]
+  x_names = gsub("\n    ", "", x_names)
   x.variables = strsplit(x_names," [\\+\\*:] ")[[1]]
   temp.data = model$model
   temp.dataframe = eval(model$call$data)


### PR DESCRIPTION
Since "as.character()" splits lines at 500 characters, expansively named regressions or regressions with lots of explanatory variables produced an error due to insertion of \n. Fixed this by replacing any \n (and the attached spaces) with an empty string. 